### PR TITLE
feat(eslint): adjust curly rule to always require braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
   rules: {
     "prettier/prettier": "error",
 
+
     "destructuring/in-methods-params": "error",
     "compat/compat": "error",
 
@@ -21,6 +22,7 @@ module.exports = {
     "multiline-ternary": "off", // allow both multiline and single line
 
     // Airbnb overrides
+    "curly": ["error", "all"],
     "react/jsx-filename-extension": "off", // Allow JSX in .js files
     "no-mixed-operators": ["error", {
       "groups": [


### PR DESCRIPTION
Overwrite Airbnb `curly` rule configuration to enforce that the statement body is always(!) wrapped in a block. Sticking with this rule will make it easier to maintain code in the long run.